### PR TITLE
Fix de242c7 (#40)

### DIFF
--- a/src/v/x.c
+++ b/src/v/x.c
@@ -131,14 +131,16 @@ void init_font(char * fontname){
   else{
     PRINT_WARN("cannot load font '%s'\n", fontname);
   }
+
+  XCharStruct _o;
+  int _d, font_ascent, font_descent;
+  XQueryTextExtents(world.dis, XGContextFromGC(world.gc_black), ".", 1, &_d, &font_ascent, &font_descent, &_o);
+  world.font_height = font_ascent + font_descent;
   return;
 }
 
 void textincorner(const char * const lines[MAX_LINES], const int red[MAX_LINES]){
-  XCharStruct _o;
-  int _d, font_ascent, font_descent;
-  XQueryTextExtents(world.dis, XGContextFromGC(world.gc_black), ".", 1, &_d, &font_ascent, &font_descent, &_o);
-  int voffset = font_ascent + font_descent + 5;
+  int voffset = world.font_height + 5;
   int hoffset = 10;
   for(int i=0; i<MAX_LINES; i++){
     if(lines[i]){

--- a/src/v/x.h
+++ b/src/v/x.h
@@ -17,5 +17,6 @@ typedef struct {
   Pixmap    px;
   Drawable  canv;
   XFontStruct * fontInfo;
+  int       font_height;
   int       W, H, size;
 } draw_world_t;


### PR DESCRIPTION
Apparently XQueryTextExtents() does not mess up with the event,
but is too expensive. Anyway, now it's called only once
after initializing the font
